### PR TITLE
Pixiv小説のルビ記法をパースできるようにした

### DIFF
--- a/__tests__/main_test.ts
+++ b/__tests__/main_test.ts
@@ -45,6 +45,9 @@ def
 あああ\`あああ　\`
 
 [newpage]
+
+[[rb:漢字 > ふりがな]]
+と書くとルビがふれる。
 `
     const expected = `　ａｂｃｄｅｆ
 　ａａａ
@@ -59,6 +62,7 @@ def
 　あああ
 　ああああああ
 [newpage]
+　[[rb:漢字 > ふりがな]]と書くとルビがふれる。
 `
     const result = transform(text)
     expect(result).toBe(expected)

--- a/__tests__/main_test.ts
+++ b/__tests__/main_test.ts
@@ -36,7 +36,15 @@ def
 
 あー！!!!??
 
+あああ
+
+[newline]
+
+あああ
+
 あああ\`あああ　\`
+
+[newpage]
 `
     const expected = `　ａｂｃｄｅｆ
 　ａａａ
@@ -46,7 +54,11 @@ def
 　はぁ。「ちょっと待ってよ」と言った。
 　心の中では（うん？　なんだかな？）と思いながらも、ついていくしかなかった。
 　あー！！！！？？
+　あああ
+
+　あああ
 　ああああああ
+[newpage]
 `
     const result = transform(text)
     expect(result).toBe(expected)

--- a/pnovel.js
+++ b/pnovel.js
@@ -52,7 +52,7 @@ sentence = content:content+ _ blank? {
   return {type: "sentence", contents: content}
 }
 
-content = newLineToken / specialToken / rawBlock / rawToken / comment / speakend / thinkend / text
+content = newLineToken / pixivRubyToken / specialToken / rawBlock / rawToken / comment / speakend / thinkend / text
 
 text = _ text:contentChars _ blank? {
   return {type: "text", contents: text}
@@ -75,6 +75,10 @@ rawBlock = _ "```" blank? text:([^\n"`"]+ blank?)+ _ blank? _ "```" blank? {
 
 specialToken = _ "[" text:[^\]\n]+ "]" _ blank? {
   return {type: "raw", contents: "[" + text.join("") + "]"}
+}
+
+pixivRubyToken = _ "[" "[" text:[^\]\n]+ "]" "]" _ blank? {
+  return {type: "text", contents: "[[" + text.join("") + "]]"}
 }
 
 newLineToken = _ "[newline]" _ blank? {


### PR DESCRIPTION
closes #57 

[newpage] とかと同じく、実質raw記法。ただし type はテキストにした。