### PR TITLE
複数空行で複数改行されるのを修正

### DIFF
--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -52,6 +52,9 @@ def
 % コメント
 
 あああ % コメント
+
+
+あいうえお
 `
     const expected = `　ａｂｃｄｅｆ
 　ａａａ
@@ -68,6 +71,7 @@ def
 [newpage]
 　[[rb:漢字 > ふりがな]]と書くとルビがふれる。
 　あああ
+　あいうえお
 `
     const result = transform(text)
     expect(result).toBe(expected)

--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -55,6 +55,8 @@ def
 
 
 あいうえお
+
+\`ざあ　　ざ　　あ！あ\`
 `
     const expected = `　ａｂｃｄｅｆ
 　ａａａ
@@ -72,6 +74,7 @@ def
 　[[rb:漢字 > ふりがな]]と書くとルビがふれる。
 　あああ
 　あいうえお
+ざあ　　ざ　　あ！あ
 `
     const result = transform(text)
     expect(result).toBe(expected)

--- a/src/__tests__/parser.spec.ts
+++ b/src/__tests__/parser.spec.ts
@@ -99,6 +99,9 @@ boo
 わー！？
 
 ！！！！！！！
+
+
+あいうえお
 `
     const expected = {
       type: 'doc',
@@ -360,8 +363,18 @@ boo
           contents: [
             { type: 'text', contents: '！！！！！！！　' }
           ]
+        },
+        {
+          type: 'break',
+          contents: []
+        },
+        {
+          type: 'sentence',
+          contents: [{
+            type: 'text',
+            contents: 'あいうえお'
+          }]
         }
-
       ]
     }
     expect(parse(input)).toStrictEqual(expected)

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -66,6 +66,9 @@ function parseDocumentBlock (node: DocumentBlock): string {
     case 'header': {
       return `[chapter:${results.join()}]`
     }
+    case 'break': {
+      return ''
+    }
     default: {
       return results.join('')
     }


### PR DESCRIPTION
### 現在の挙動

```
あ

あ
```

が

```
　あ

　あ
```

### 期待される挙動

```
　あ
　あ
```
