### PR TITLE
コメントの影響を除く関数をeval側に実装

### DIFF
--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -57,6 +57,12 @@ def
 あいうえお
 
 \`ざあ　　ざ　　あ！あ\`
+
+% コメント
+「あああ」
+
+% コメントセカンドシーズン
+（あああ）
 `
     const expected = `　ａｂｃｄｅｆ
 　ａａａ
@@ -75,6 +81,8 @@ def
 　あああ
 　あいうえお
 ざあ　　ざ　　あ！あ
+「あああ」
+（あああ）
 `
     const result = transform(text)
     expect(result).toBe(expected)

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -22,17 +22,20 @@ function excludeCommentNode (node: DocumentBlock): DocumentBlock {
   })
   if (newContents.length === 0) return { type: 'sentence', contents: [] }
   if (type !== 'sentence') return { type: type, contents: newContents }
-  if (newContents[0].contents[0] === '（') return { type: 'thinking', contents: newContents }
-  if (newContents[0].contents[0] === '「') return { type: 'speaking', contents: newContents }
+  if (newContents[0].contents[0] === '（') return { type: 'thinking', contents: trimFirstSymbol(newContents) }
+  if (newContents[0].contents[0] === '「') return { type: 'speaking', contents: trimFirstSymbol(newContents) }
   return { type: type, contents: newContents }
+}
+
+function trimFirstSymbol (tokens: DocumentToken[]): DocumentToken[] {
+  const head = tokens[0]
+  head.contents = head.contents.slice(1)
+  return tokens
 }
 
 export function parseDocumentToken (node: DocumentToken): string {
   const { type, contents } = node
   switch (type) {
-    case 'comment': {
-      return ''
-    }
     case 'speechend': {
       return contents + '」'
     }


### PR DESCRIPTION
- commentを除いた状態にする関数を実装
- コメントを無視した状態でノードの種類の判定を実施
    - 本当はパーサーレベルで直したい