### PR TITLE
コメントが空白文字のみだとシンタックスエラーが出るのを修正

### DIFF
--- a/pnovel.js
+++ b/pnovel.js
@@ -57,7 +57,7 @@ content = newLineToken / pixivRubyToken / specialToken / rawBlock / rawToken / c
 text = _ text:contentChars _ blank? {
   return {type: "text", contents: text}
 }
-comment = _ "%" _ text:[^\n]+ _ blank {
+comment = _ "%" _ text:[^\n]* _ blank {
   return {type: "comment", contents: text.join("")}
 }
 

--- a/src/__tests__/parser.spec.ts
+++ b/src/__tests__/parser.spec.ts
@@ -102,6 +102,9 @@ boo
 
 
 あいうえお
+
+%
+あいうえお
 `
     const expected = {
       type: "doc",
@@ -327,6 +330,19 @@ boo
         {
           type: "sentence",
           contents: [
+            {
+              type: "text",
+              contents: "あいうえお",
+            },
+          ],
+        },
+        {
+          type: "sentence",
+          contents: [
+            {
+              type: "comment",
+              contents: "",
+            },
             {
               type: "text",
               contents: "あいうえお",


### PR DESCRIPTION
fix #86