### PR TITLE
[codex] Add static pnovel editor

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>pnovel editor</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="editor-shell">
+      <header class="topbar">
+        <div>
+          <h1>pnovel editor</h1>
+          <p>Raw text to transformed preview</p>
+        </div>
+        <div class="toolbar" aria-label="Editor controls">
+          <label class="mode-control">
+            <span>Mode</span>
+            <select id="mode-select">
+              <option value="pixiv">Pixiv</option>
+              <option value="narou">Narou</option>
+            </select>
+          </label>
+          <button id="copy-button" type="button">Copy</button>
+          <button id="clear-button" type="button">Clear</button>
+        </div>
+      </header>
+
+      <section class="workspace" aria-label="pnovel editor">
+        <section class="pane" aria-labelledby="raw-heading">
+          <div class="pane-heading">
+            <h2 id="raw-heading">Raw</h2>
+          </div>
+          <textarea id="raw-input" spellcheck="false" aria-label="Raw pnovel text"></textarea>
+        </section>
+
+        <section class="pane" aria-labelledby="preview-heading">
+          <div class="pane-heading">
+            <h2 id="preview-heading">Preview</h2>
+            <p id="error-message" role="alert"></p>
+          </div>
+          <pre id="preview-output" aria-label="Transformed preview"></pre>
+        </section>
+      </section>
+    </main>
+    <script defer src="../dist/editor.js"></script>
+  </body>
+</html>

--- a/app/styles.css
+++ b/app/styles.css
@@ -1,0 +1,206 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --panel-border: #d9dee7;
+  --text: #1f2430;
+  --muted: #667085;
+  --accent: #1c7c67;
+  --accent-strong: #145f50;
+  --danger: #b42318;
+  --control: #eef3f1;
+  --shadow: 0 16px 44px rgba(31, 36, 48, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+select,
+textarea {
+  font: inherit;
+}
+
+.editor-shell {
+  min-height: 100%;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 16px;
+  padding: 18px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
+  font-weight: 720;
+  letter-spacing: 0;
+}
+
+.topbar p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.mode-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+select,
+button {
+  height: 38px;
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--text);
+}
+
+select {
+  padding: 0 34px 0 12px;
+}
+
+button {
+  min-width: 76px;
+  padding: 0 14px;
+  cursor: pointer;
+}
+
+button:first-of-type {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+button:first-of-type:hover {
+  background: var(--accent-strong);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.workspace {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 14px;
+}
+
+.pane {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: hidden;
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.pane-heading {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.pane-heading h2 {
+  margin: 0;
+  font-size: 0.96rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+#error-message {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--danger);
+  font-size: 0.86rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+textarea,
+pre {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  margin: 0;
+  padding: 18px;
+  border: 0;
+  outline: 0;
+  resize: none;
+  overflow: auto;
+  background: #fbfcfd;
+  color: var(--text);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 15px;
+  line-height: 1.75;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+textarea:focus {
+  background: #ffffff;
+  box-shadow: inset 0 0 0 2px rgba(28, 124, 103, 0.24);
+}
+
+@media (max-width: 820px) {
+  .editor-shell {
+    padding: 12px;
+  }
+
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .toolbar {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .workspace {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(320px, 1fr) minmax(320px, 1fr);
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,4 +33,12 @@ export default [
     },
     ignores: ["pnovel.js", "dist/*.js"],
   },
+  {
+    files: ["src/editor.ts"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      },
+    },
+  },
 ]

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -22,6 +22,7 @@ export default {
   collectCoverage: true,
   collectCoverageFrom: [
     "**/*.{ts,tsx}",
+    "!**/editor.ts",
     "!**/node_modules/**"
   ],
   coverageReporters: [

--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs"
 import * as path from "path"
 
+import { jest } from "@jest/globals"
+
 import { transform, main } from "../main.ts"
 
 describe("test main", () => {
@@ -25,6 +27,19 @@ describe("test parsing", () => {
     const expected = "　ｆｏｏ\n"
     const result = transform(text, "pixiv")
     expect(result).toBe(expected)
+  })
+
+  test("debug parsing", () => {
+    const debug = jest.spyOn(console, "debug").mockImplementation(() => {})
+    try {
+      const text = "foo\n"
+      const expected = "　ｆｏｏ\n"
+      const result = transform(text, "pixiv", true)
+      expect(result).toBe(expected)
+      expect(debug).toHaveBeenCalledTimes(1)
+    } finally {
+      debug.mockRestore()
+    }
   })
 
   test("do not have last newline", () => {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,0 +1,67 @@
+import { transform, type Mode } from "./transform.ts"
+
+const initialText = `# タイトル
+
+こんにちは。 % コメントは出力されません
+こんばんは
+
+「会話文です」
+
+|漢字<ふりがな>にルビを振れます。
+`
+
+function queryRequired<T extends Element>(selector: string): T {
+  const element = document.querySelector<T>(selector)
+  if (!element) {
+    throw new Error(`Editor element is missing: ${selector}`)
+  }
+  return element
+}
+
+const rawInput = queryRequired<HTMLTextAreaElement>("#raw-input")
+const previewOutput = queryRequired<HTMLElement>("#preview-output")
+const modeSelect = queryRequired<HTMLSelectElement>("#mode-select")
+const errorMessage = queryRequired<HTMLElement>("#error-message")
+const copyButton = queryRequired<HTMLButtonElement>("#copy-button")
+const clearButton = queryRequired<HTMLButtonElement>("#clear-button")
+
+rawInput.value = initialText
+
+function getMode(): Mode {
+  return modeSelect.value === "narou" ? "narou" : "pixiv"
+}
+
+function renderPreview() {
+  try {
+    const result = transform(rawInput.value, getMode())
+    previewOutput.textContent = result
+    errorMessage.textContent = ""
+    copyButton.disabled = result.length === 0
+  } catch (error: unknown) {
+    previewOutput.textContent = ""
+    copyButton.disabled = true
+    errorMessage.textContent = error instanceof Error ? error.message : String(error)
+  }
+}
+
+rawInput.addEventListener("input", renderPreview)
+modeSelect.addEventListener("change", renderPreview)
+
+copyButton.addEventListener("click", async() => {
+  const text = previewOutput.textContent ?? ""
+  if (text.length === 0) return
+
+  await navigator.clipboard.writeText(text)
+  copyButton.textContent = "Copied"
+  window.setTimeout(() => {
+    copyButton.textContent = "Copy"
+  }, 900)
+})
+
+clearButton.addEventListener("click", () => {
+  rawInput.value = ""
+  rawInput.focus()
+  renderPreview()
+})
+
+renderPreview()

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,14 +4,11 @@ import * as process from "process"
 
 import { Command } from "commander"
 
-// @ts-ignore
-import { parse } from "../parser/parser"
-import { PixivNovelTransformer } from "./pixivNovelTransformer.ts"
-import { NarouSyosetsuTransformer } from "./narouSyosetsuTransformer.ts"
+import { transform, type Mode } from "./transform.ts"
+
+export { transform } from "./transform.ts"
 
 const VERSION = "v0.7.9"
-
-type Mode = "pixiv" | "narou"
 
 type CommandField = {
   debug: any
@@ -87,22 +84,6 @@ function addLastEmptyLine(content: string) {
   return content
 }
 
-export function transform(content: string, mode: Mode): string {
-  content = addLastEmptyLine(content)
-  const jsonContent = parse(content)
-  if (program.opts().debug) console.debug(JSON.stringify(jsonContent))
-  let transformer
-  switch (mode) {
-    case "pixiv":
-      transformer = new PixivNovelTransformer(jsonContent)
-      break
-    default:
-      transformer = new NarouSyosetsuTransformer(jsonContent)
-      break
-  }
-  return transformer.transform()
-}
-
 export function main(): void {
   try {
     initProgram()
@@ -127,7 +108,7 @@ export function main(): void {
   }
 
   const fileContent = readFile(file)
-  const transformedContent = transform(fileContent, program.opts().mode)
+  const transformedContent = transform(fileContent, program.opts().mode, program.opts().debug)
   if (program.opts().output) {
     writeFile(program.opts().output, transformedContent)
     return

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,0 +1,22 @@
+// @ts-ignore
+import { parse } from "../parser/parser"
+import { NarouSyosetsuTransformer } from "./narouSyosetsuTransformer.ts"
+import { PixivNovelTransformer } from "./pixivNovelTransformer.ts"
+
+export type Mode = "pixiv" | "narou"
+
+function addLastEmptyLine(content: string) {
+  if (content.slice(-1) !== "\n") {
+    content += "\n"
+  }
+  return content
+}
+
+export function transform(content: string, mode: Mode, debug = false): string {
+  content = addLastEmptyLine(content)
+  const jsonContent = parse(content)
+  if (debug) console.debug(JSON.stringify(jsonContent))
+  const transformer =
+    mode === "pixiv" ? new PixivNovelTransformer(jsonContent) : new NarouSyosetsuTransformer(jsonContent)
+  return transformer.transform()
+}

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -5,7 +5,7 @@ import nodeExternals from 'webpack-node-externals';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 
-export default {
+const nodeConfig = {
   entry: "./src/main.ts",
   target: "node",
   mode: "production",
@@ -49,3 +49,35 @@ export default {
     minimize: true,
   },
 };
+
+const browserConfig = {
+  entry: "./src/editor.ts",
+  target: "web",
+  mode: "production",
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'editor.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "ts-loader",
+          options: {
+            transpileOnly: true,
+          },
+        }
+      }
+    ]
+  },
+  resolve: {
+    extensions: [".js", ".ts"],
+  },
+  optimization: {
+    minimize: true,
+  },
+};
+
+export default [nodeConfig, browserConfig];


### PR DESCRIPTION
## Summary
- Add a lightweight static editor page with raw pnovel input on the left and transformed preview on the right.
- Split the transform core out of the CLI entrypoint so it can be reused in the browser bundle.
- Add a browser webpack target that emits `dist/editor.js` alongside the existing CLI build.

## Notes
- The editor is frontend-only: no server, database, file management, or backend API.
- The editor currently uses a plain textarea to keep the experience light.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- Manual browser check: entering `foo` updates the preview to `　ｆｏｏ`.