### PR TITLE
[codex] Fix ruby parsing in speaking text

### DIFF
--- a/pnovel.peggy
+++ b/pnovel.peggy
@@ -25,6 +25,18 @@
     return useTexts
   }
 
+  function flattenSymbols(texts) {
+    const useTexts = []
+    texts.forEach((text) => {
+      if (text[2]) {
+        useTexts.push(text[0] + text[2])
+        return
+      }
+      useTexts.push(text[0])
+    })
+    return useTexts
+  }
+
 }
 
 start = doc
@@ -44,11 +56,11 @@ emptyHeader = "#" blank? {
   return {type: "sentence", contents: [{ type: 'text', contents: '#'}]}
 }
 
-speaking = _ "「" _ content:content+  blank? {
+speaking = _ "「" _ content:speechContent+  blank? {
   return {type: "speaking", contents: content}
 }
 
-thinking = _ "（" _ content:content+ blank? {
+thinking = _ "（" _ content:thinkContent+ blank? {
   return { type: "thinking", contents: content}
 }
 
@@ -58,8 +70,17 @@ sentence = content:content+ _ blank? {
 
 content = newLineToken / pixivRubyToken / rubyToken / specialToken / rawBlock / rawToken / comment / speakend / thinkend / text
 
+speechContent = newLineToken / pixivRubyToken / rubyToken / specialToken / rawBlock / rawToken / comment / speakend / speakclose / speechText
+
+thinkContent = newLineToken / pixivRubyToken / rubyToken / specialToken / rawBlock / rawToken / comment / thinkend / thinkclose / speechText
+
 text = _ text:contentChars _ blank? {
   return {type: "text", contents: text}
+}
+
+speechText = _ texts:(speechChars _ specialSymbol?)+ _ blank? {
+  const useTexts = flattenSymbols(texts)
+  return {type: "text", contents: useTexts.join("")}
 }
 comment = _ "%" _ text:[^\n]* _ blank {
   return {type: "comment", contents: text.join("")}
@@ -103,8 +124,16 @@ thinkend = _ texts:(speechChars _ specialSymbol?)+ "）" _ blank? {
   return {type: "thinkend", contents: useTexts.join("") }
 }
 
+speakclose = _ "」" _ blank? {
+  return {type: "speechend", contents: "" }
+}
 
-char = [^「」（）\[\]!?！？`%#\n]
+thinkclose = _ "）" _ blank? {
+  return {type: "thinkend", contents: "" }
+}
+
+
+char = [^「」（）\[\]!?！？`|%#\n]
 contentChar = [^\[\]!?！？`|%#\n]
 
 useChar = whitespace / endOfSpecialSymbol / specialSymbol / hankakuEisu / char

--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -158,6 +158,23 @@ def
     expect(result).toBe(expected)
   })
 
+  test("pixiv ruby in speaking", () => {
+    const text = `「|漢字<かんじ>にルビ」
+「これは|漢字<かんじ>です」
+「これは、|漢字<かんじ>です」
+「|漢字<かんじ>と|言葉<ことば>です」
+「これは|漢字<かんじ>」
+`
+    const expected = `「[[rb:漢字 > かんじ]]にルビ」
+「これは[[rb:漢字 > かんじ]]です」
+「これは、[[rb:漢字 > かんじ]]です」
+「[[rb:漢字 > かんじ]]と[[rb:言葉 > ことば]]です」
+「これは[[rb:漢字 > かんじ]]」
+`
+    const result = transform(text, "pixiv")
+    expect(result).toBe(expected)
+  })
+
   test("narou toransformer", () => {
     const text = "# foo\n"
     const expected = "\nｆｏｏ\n\n"
@@ -168,6 +185,23 @@ def
   test("narou ruby", () => {
     const text = "こんにちは、|こんにちは<こんにちは>、こんにちは"
     const expected = "　こんにちは、|こんにちは《こんにちは》、こんにちは\n"
+    const result = transform(text, "narou")
+    expect(result).toBe(expected)
+  })
+
+  test("narou ruby in speaking", () => {
+    const text = `「|漢字<かんじ>にルビ」
+「これは|漢字<かんじ>です」
+「これは、|漢字<かんじ>です」
+「|漢字<かんじ>と|言葉<ことば>です」
+「これは|漢字<かんじ>」
+`
+    const expected = `「|漢字《かんじ》にルビ」
+「これは|漢字《かんじ》です」
+「これは、|漢字《かんじ》です」
+「|漢字《かんじ》と|言葉《ことば》です」
+「これは|漢字《かんじ》」
+`
     const result = transform(text, "narou")
     expect(result).toBe(expected)
   })

--- a/src/__tests__/parser.spec.ts
+++ b/src/__tests__/parser.spec.ts
@@ -388,4 +388,33 @@ boo
     }
     expect(parse(input)).toStrictEqual(expected)
   })
+
+  test("parse ruby tokens in speaking", () => {
+    const input = `「これは|漢字<かんじ>と|言葉<ことば>です」
+「これは|漢字<かんじ>」`
+    const expected = {
+      type: "doc",
+      contents: [
+        {
+          type: "speaking",
+          contents: [
+            { type: "text", contents: "これは" },
+            { type: "ruby", contents: "漢字", yomi: "かんじ" },
+            { type: "text", contents: "と" },
+            { type: "ruby", contents: "言葉", yomi: "ことば" },
+            { type: "speechend", contents: "です" },
+          ],
+        },
+        {
+          type: "speaking",
+          contents: [
+            { type: "text", contents: "これは" },
+            { type: "ruby", contents: "漢字", yomi: "かんじ" },
+            { type: "speechend", contents: "" },
+          ],
+        },
+      ],
+    }
+    expect(parse(input)).toStrictEqual(expected)
+  })
 })

--- a/src/pixivNovelTransformer.ts
+++ b/src/pixivNovelTransformer.ts
@@ -16,12 +16,9 @@ export class PixivNovelTransformer {
     })
     switch (type) {
       case "sentence": {
-        let text = ""
-        if (["raw", "pixivToken"].includes(contents[0].type)) {
-          text = results.join("")
-        } else {
-          text = "　" + results.join("")
-        }
+        const text = ["raw", "pixivToken"].includes(contents[0].type)
+          ? results.join("")
+          : "　" + results.join("")
         if (text.slice(-1)[0] === "　") return text.slice(0, text.length - 1)
         return text
       }


### PR DESCRIPTION
## Summary

Fixes ruby markup parsing inside speaking/thinking blocks so `|漢字<かんじ>` is recognized even after normal dialogue text.

## Details

The parser previously allowed `|` inside `speechChars`, so `speakend` / `thinkend` could consume the rest of a dialogue/thinking block as one `speechend` / `thinkend` token. That meant ruby markup after ordinary text, such as `「これは|漢字<かんじ>です」`, was treated as plain text.

This change:

- Adds dedicated `speechContent` and `thinkContent` parser paths for speaking/thinking blocks
- Keeps special symbol handling for dialogue text
- Adds close-only tokens so dialogue can end immediately after a ruby token
- Adds regression coverage for pixiv and narou output
- Includes a small lint cleanup in `PixivNovelTransformer`

Fixes #282.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- Manual CLI checks with `node bin/pnovel.js --stdin -m pixiv`
- Manual CLI checks with `node bin/pnovel.js --stdin -m narou`